### PR TITLE
ExpressibleByStringLiteral Conformance for Modifier

### DIFF
--- a/Sources/WindRoseCore/Modifier.swift
+++ b/Sources/WindRoseCore/Modifier.swift
@@ -192,7 +192,7 @@ public extension Modifier {
     /// CSS: `&:last-of-type`
     static let lastOfType: Self = "last-of-type"
 
-    /// CSS: [`dir="rtl"] &`
+    /// CSS: `[dir="rtl"] &`
     static let ltr: Self = "ltr"
 
     /// CSS: `&::marker`


### PR DESCRIPTION
Declares `ExpressibleByStringLiteral` conformance for `Modifier` and changes member declarations to use it.